### PR TITLE
Update Philo MSO

### DIFF
--- a/yt_dlp/extractor/adobepass.py
+++ b/yt_dlp/extractor/adobepass.py
@@ -1574,18 +1574,34 @@ class AdobePassIE(InfoExtractor):  # XXX: Conventionally, base classes should en
                             post_form(mvpd_confirm_page_res, 'Confirming Login')
                 elif mso_id == 'Philo':
                     # Philo has very unique authentication method
-                    self._download_webpage(
-                        'https://idp.philo.com/auth/init/login_code', video_id, 'Requesting auth code', data=urlencode_postdata({
-                            'ident': username,
-                            'device': 'web',
-                            'send_confirm_link': False,
-                            'send_token': True,
-                        }))
+                    philo_ident_payload = {
+                        'ident': username,
+                        'device': 'web',
+                        'send_confirm_link': False,
+                        'send_token': True,
+                        'device_ident': f'web-{uuid.uuid4().hex}',
+                        'include_login_link': True,
+                    }
+
+                    self._download_json_handle(
+                        'https://idp.philo.com/auth/init/login_code', video_id,
+                        note='Requesting Philo auth code', data=json.dumps(philo_ident_payload).encode('utf-8'),
+                        headers={
+                            'Content-Type': 'application/json',
+                            'Accept': 'application/json',
+                        })
+
                     philo_code = getpass.getpass('Type auth code you have received [Return]: ')
-                    self._download_webpage(
-                        'https://idp.philo.com/auth/update/login_code', video_id, 'Submitting token', data=urlencode_postdata({
-                            'token': philo_code,
-                        }))
+
+                    update_code_payload = {'token': philo_code}
+                    self._download_json_handle(
+                        'https://idp.philo.com/auth/update/login_code', video_id,
+                        note='Submitting token', data=json.dumps(update_code_payload).encode('utf-8'),
+                        headers={ 
+                            'Content-Type': 'application/json',
+                            'Accept': 'application/json',
+                        })
+
                     mvpd_confirm_page_res = self._download_webpage_handle('https://idp.philo.com/idp/submit', video_id, 'Confirming Philo Login')
                     post_form(mvpd_confirm_page_res, 'Confirming Login')
                 elif mso_id == 'Verizon':


### PR DESCRIPTION
<!--
    **IMPORTANT**: PRs without the template will be CLOSED
    
    Due to the high volume of pull requests, it may be a while before your PR is reviewed.
    Please try to keep your pull request focused on a single bugfix or new feature.
    Pull requests with a vast scope and/or very large diff will take much longer to review.
    It is recommended for new contributors to stick to smaller pull requests, so you can receive much more immediate feedback as you familiarize yourself with the codebase.

    PLEASE AVOID FORCE-PUSHING after opening a PR, as it makes reviewing more difficult.
-->

### Description of your *pull request* and other information

This fixes the Philo login for TVE. It's been broken for a while but so was the adobepass, but now that it is fixed, figured we should get this up and running as well. This was tested and confirmed to work on aetv.com (updated with PR-13131)

Fixes #2603

Test:

```[debug] Command-line config: ['--ap-mso', 'Philo', '--ap-username', 'PRIVATE', '--ap-password', 'PRIVATE', '-F', 'https://play.aetv.com/shows/neighborhood-wars/season-8/episode-99', '-v', '--no-cache-dir']
[debug] Encodings: locale cp1252, fs utf-8, pref cp1252, out utf-8, error utf-8, screen utf-8 
[debug] yt-dlp version stable@2025.05.22 from yt-dlp/yt-dlp [7977b329e] (pip)
[debug] Python 3.12.2 (CPython AMD64 64bit) - Windows-10-10.0.18363-SP0 (OpenSSL 3.0.13 30 Jan 2024) 
[debug] exe versions: ffmpeg 2025-05-01-git-707c04fe06-full_build-www.gyan.dev (setts), ffprobe 2025-05-01-git-707c04fe06-full_build-www.gyan.dev, rtmpdump 2.4 
[debug] Optional libraries: Cryptodome-3.21.0, brotli-1.1.0, certifi-2024.08.30, mutagen-1.47.0, requests-2.29.0 (unsupported), sqlite3-3.43.1, urllib3-1.26.20, websockets-13.1
[debug] Proxy map: {}
[debug] Request Handlers: urllib, websockets
[debug] Plugin directories: none
[debug] Loaded 1859 extractors 
[aenetworks] Extracting URL: https://play.aetv.com/shows/neighborhood-wars/season-8/episode-99 
[aenetworks] /shows/neighborhood-wars/season-8/episode-99: Downloading JSON metadata 
[aenetworks] 2428793923886: Downloading JSON metadata 
[aenetworks] 2428793923886: Registering device with Adobe 
[aenetworks] 2428793923886: Registering client with Adobe 
[aenetworks] 2428793923886: Obtaining access token 
[aenetworks] 2428793923886: Obtaining registration code 
[aenetworks] 2428793923886: Downloading Provider Redirect Page 
[aenetworks] 2428793923886: Requesting Philo auth code 
Type auth code you have received [Return]: 
[aenetworks] 2428793923886: Submitting token
[aenetworks] 2428793923886: Confirming Philo Login 
[aenetworks] 2428793923886: Confirming Login 
[aenetworks] 2428793923886: Retrieving Session 
[aenetworks] 2428793923886: Retrieving Authorization Token 
[aenetworks] 2428793923886: Retrieving Media Token 
[aenetworks] 2428793923886: Downloading hls_high_ak SMIL data 
[aenetworks] 2428793923886: Downloading high_video_s3 SMIL data 
[aenetworks] 2428793923886: Downloading hls_high_fastly SMIL data 
[aenetworks] 2428793923886: Downloading m3u8 information 
[debug] Formats sorted by: hasvid, ie_pref, lang, quality, res, fps, hdr:12(7), vcodec, channels, acodec, size, br, asr, proto, vext, aext, hasaud, source, id 
[info] Available formats for 2428793923886: 
ID              EXT RESOLUTION FPS │   FILESIZE   TBR PROTO │ VCODEC        VBR ACODEC     MORE INFO 
───────────────────────────────────────────────────────────────────────────────────────────────────────
hls-AAC-English mp4 audio only     │                  m3u8  │ audio only        unknown    [en] English
hls-177         mp4 320x180     30 │ ~ 25.92MiB  177k m3u8  │ avc1.4d400d  177k video only
hls-285         mp4 320x180     30 │ ~ 41.80MiB  286k m3u8  │ avc1.4d400d  286k video only
hls-502         mp4 448x252     30 │ ~ 73.43MiB  502k m3u8  │ avc1.4d4015  502k video only
hls-817         mp4 512x288     30 │ ~119.51MiB  817k m3u8  │ avc1.4d4015  817k video only
hls-1123        mp4 640x360     30 │ ~164.22MiB 1123k m3u8  │ avc1.4d401e 1123k video only
hls-1425        mp4 768x432     30 │ ~208.48MiB 1426k m3u8  │ avc1.4d401e 1426k video only
hls-1935        mp4 960x540     30 │ ~282.96MiB 1935k m3u8  │ avc1.4d401f 1935k video only
hls-2639        mp4 1280x720    30 │ ~385.98MiB 2640k m3u8  │ avc1.4d401f 2640k video only
```

<details open><summary>Template</summary> <!-- OPEN is intentional -->

<!--
    # PLEASE FOLLOW THE GUIDE BELOW

    - You will be asked some questions, please read them **carefully** and answer honestly
    - Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
    - Use *Preview* tab to see what your *pull request* will actually look like
-->

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [contributing guidelines](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#developer-instructions) including [yt-dlp coding conventions](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#yt-dlp-coding-conventions)
- [X] [Searched](https://github.com/yt-dlp/yt-dlp/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into yt-dlp each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check those that apply and remove the others:
- [X] I am the original author of the code in this PR, and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of the code in this PR, but it is in the public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*? Check those that apply and remove the others:
- [ ] Fix or improvement to an extractor (Make sure to add/update tests)
- [ ] New extractor ([Piracy websites will not be accepted](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#is-the-website-primarily-used-for-piracy))
- [X] Core bug fix/improvement
- [ ] New feature (It is strongly [recommended to open an issue first](https://github.com/yt-dlp/yt-dlp/blob/master/CONTRIBUTING.md#adding-new-feature-or-making-overarching-changes))

</details>
